### PR TITLE
Fix regex for image links

### DIFF
--- a/script.js
+++ b/script.js
@@ -271,9 +271,9 @@ jQuery(document).ready(function($) {
 					}
 
 					let preventClick = 0;
-					if (check && blpwp_params['options'].imagelinks == '' && h.match(/(\.(jpe?g|gif|png|webp))$/, 'i') && $(this).find("img").length == 1 && $(this).children().length == 1) {
-						check = false;
-					}
+                                        if (check && blpwp_params['options'].imagelinks == '' && h.match(/(\.(jpe?g|gif|png|webp))$/i) && $(this).find("img").length == 1 && $(this).children().length == 1) {
+                                               check = false;
+                                       }
 
 					if (check) {
 


### PR DESCRIPTION
## Summary
- avoid unsupported second argument to `String.prototype.match`
- fix image file extension regex by adding case-insensitive flag

## Testing
- `npx eslint --print-config script.js >/dev/null` *(fails: `npx` not found)*

------
https://chatgpt.com/codex/tasks/task_e_686b886c670c832cba167ee229887b1d