### PR TITLE
Add ABSPATH checks to entry files

### DIFF
--- a/ajax.php
+++ b/ajax.php
@@ -1,4 +1,7 @@
 <?php
+if ( ! defined( 'ABSPATH' ) ) {
+    exit;
+}
 
 
 //

--- a/docs/index.php
+++ b/docs/index.php
@@ -1,4 +1,7 @@
 <?php
+if ( ! defined( 'ABSPATH' ) ) {
+    exit;
+}
 //
 // This file parse the HTML of the BrightLinks docs
 // add some styles and print everything in HTML.

--- a/index.php
+++ b/index.php
@@ -1,4 +1,7 @@
 <?php
+if ( ! defined( 'ABSPATH' ) ) {
+    exit;
+}
 /*
 Plugin Name: Bright Link Previews
 Plugin URI: http://www.barattalo.it/

--- a/paging.php
+++ b/paging.php
@@ -1,4 +1,7 @@
 <?php
+if ( ! defined( 'ABSPATH' ) ) {
+    exit;
+}
 
 
 

--- a/settings-page.php
+++ b/settings-page.php
@@ -1,4 +1,7 @@
 <?php
+if ( ! defined( 'ABSPATH' ) ) {
+    exit;
+}
 //
 // Using WP settings api to build a complex setting page for the plugin
 //


### PR DESCRIPTION
## Summary
- improve WordPress security by checking `ABSPATH` at the start of
  - `index.php`
  - `ajax.php`
  - `paging.php`
  - `settings-page.php`
  - `docs/index.php`

## Testing
- `php -l index.php` *(fails: `php` not found)*

------
https://chatgpt.com/codex/tasks/task_e_686b927fd068832c88440c36d72f3403